### PR TITLE
Change PVC from gluster-file to netapp-file-standard

### DIFF
--- a/tools/jenkins/openshift/deploy-master.yaml
+++ b/tools/jenkins/openshift/deploy-master.yaml
@@ -34,8 +34,7 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      volume.beta.kubernetes.io/storage-class: gluster-file
-      volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/glusterfs
+      volume.beta.kubernetes.io/storage-class: netapp-file-standard
     name: ${NAME}${SUFFIX}
   spec:
     accessModes:


### PR DESCRIPTION
Gluster is deprecated. We need to use netapp now for all PVC requests. This PR fixes that.