### PR TITLE
Update SonarQube Server to version 6.7.7

### DIFF
--- a/tools/jenkins/openshift/build-slave.yaml
+++ b/tools/jenkins/openshift/build-slave.yaml
@@ -42,7 +42,7 @@ objects:
     source:
       dockerfile: |
         FROM BuildConfig
-        ARG NODE_VERSION=v10.16.0
+        ARG NODE_VERSION=v12.17.0
         ARG SONAR_VERSION=3.3.0.1492
         USER 0
         RUN fix_permission() { while [[ $# > 0 ]] ; do chgrp -R 0 "$1" && chmod -R g=u "$1"; shift; done } && \

--- a/tools/metabase/README.md
+++ b/tools/metabase/README.md
@@ -8,7 +8,7 @@ While Metabase does provide a Docker image [here](https://hub.docker.com/r/metab
 
 ``` sh
 export BASE_URL="https://raw.githubusercontent.com/bcgov/nr-showcase-devops-tools/master/tools/metabase/openshift"
-export NAMESPACE=wxpbtr-dev
+export NAMESPACE=<YOURNAMESPACE>
 export METABASE_VERSION=v0.35.3
 
 oc process -n $NAMESPACE -f $BASE_URL/metabase.bc.yaml -p METABASE_VERSION=$METABASE_VERSION -o yaml | oc apply -n $NAMESPACE -f -
@@ -22,9 +22,9 @@ Once your metabase image has been successfully built, you can then deploy it in 
 
 ``` sh
 export ADMIN_EMAIL=NR.CommonServiceShowcase@gov.bc.ca
-export NAMESPACE=wxpbtr-dev
+export NAMESPACE=<YOURNAMESPACE>
 
-oc process -n $NAMESPACE -f $BASE_URL//metabase.dc.yaml ADMIN_EMAIL=$ADMIN_EMAIL NAMESPACE=$NAMESPACE -o yaml | oc apply -n $NAMESPACE -f -
+oc process -n $NAMESPACE -f $BASE_URL/metabase.dc.yaml ADMIN_EMAIL=$ADMIN_EMAIL NAMESPACE=$NAMESPACE -o yaml | oc apply -n $NAMESPACE -f -
 ```
 
 This will create a new Secret, Service, Route, Persistent Volume Claim, and Deployment Configuration. This Deployment Config has liveliness and readiness checks built in, and handles image updates via Recreation strategy. A rolling update cannot work because the H2 database is locked by the old running pod and prevents the newer instance of Metabase from starting up.


### PR DESCRIPTION
- Update Jenkins slave node version to v12.17.0
- Fix some typos and documentation notes

Later versions of sonar-scanner-cli do not play nice with SonarQube (illegal operation errors, didn't dig too deeply to find root cause). We were able to update SonarQube server to 6.7.7, but any 7.x versions and above with the bcgovimages/sonarqube image do not work because those later image versions are missing Languages and Quality Profiles. Without those, sonar-scanner fails to execute.

[SHOWCASE-1022](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1022)