### PR TITLE
Change default jenkins-basic image tag from latest to stable

### DIFF
--- a/tools/jenkins/openshift/build-master.yaml
+++ b/tools/jenkins/openshift/build-master.yaml
@@ -73,7 +73,7 @@ parameters:
   value: bcgov
 - name: SOURCE_IMAGE_STREAM_TAG
   required: true
-  value: jenkins-basic:v2-latest
+  value: jenkins-basic:v2-stable
 - name: SOURCE_REPOSITORY_URL
   required: true
 - name: SOURCE_REPOSITORY_REF


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR changes the stream from latest to stable as there was an update in upstream Jenkins image that causes our entire pipeline to not work. This will need to be investigated at a later date - for now we're locking to an older stable version.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->