### PR TITLE
Bugfix: Make Jenkins PVC ReadWriteMany

### DIFF
--- a/tools/jenkins/openshift/deploy-master.yaml
+++ b/tools/jenkins/openshift/deploy-master.yaml
@@ -58,7 +58,7 @@ objects:
     name: ${NAME}${SUFFIX}
   spec:
     accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
     storageClassName: netapp-file-standard
     resources:
       requests:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
- Make Jenkins PVC ReadWriteMany
  - Both the master and worker use the same PVC - don't want worker stopping the master from spinning up
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2060](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2060)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->